### PR TITLE
refactor(lib/layers): dynamic input shape for `Framing` and more tests

### DIFF
--- a/lib/layers/dsp/mfcc.py
+++ b/lib/layers/dsp/mfcc.py
@@ -16,7 +16,6 @@
 # ==============================================================================
 
 
-
 from typing import Union, Iterable, Tuple
 
 import numpy as np
@@ -107,9 +106,9 @@ class MFCC(Layer):
         Raises
         ------
         ValueError
-            [description]
+            If num_mfccs > num_mels.
         """
-        super(MFCC, self).__init__(trainable=False, name=name, **kwargs)
+        super(MFCC, self).__init__(trainable=False, name=name)
 
         self.numMffcs = num_mfccs
         self.melBins = num_mels
@@ -179,7 +178,16 @@ class MFCC(Layer):
 
     def get_config(self) -> dict:
         config = super(MFCC, self).get_config()
+
+        config.update(self.windowing.get_config())
+        config.update(self.filterbank.get_config())
+
         config.update({
+            "num_mfccs": self.numMffcs,
+            "num_mels": self.melBins,
+            "cepstral_lifter": self.cepstralLifter,
+            "use_energy": self.useEnergy,
+            "epsilon": self.eps.numpy(),
         })
 
         return config

--- a/lib/layers/dsp/mfcc_test.py
+++ b/lib/layers/dsp/mfcc_test.py
@@ -16,11 +16,11 @@
 # ==============================================================================
 
 
-
 import unittest
 import numpy as np
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
+import tensorflow as tf
 from tensorflow.keras.layers import Input
 from tensorflow.keras.models import Sequential
 
@@ -59,6 +59,7 @@ class TestMFCCLayer(unittest.TestCase):
                 "frame_length_ms": 25.0,
                 "frame_shift_ms": 10.0,
                 "sample_frequency": 16000.0,
+                "dynamic_input_shape": False,
             },
             "mfcc": {
                 "num_mfccs": 30,
@@ -80,23 +81,76 @@ class TestMFCCLayer(unittest.TestCase):
             }
         }
 
+    def checkTFLiteInference(
+        self, interpreter: tf.lite.Interpreter, x: np.ndarray,
+            wantFrames: int, wantDim: int, resize: bool,
+    ):
+        inputLayerIdx = interpreter.get_input_details()[0]['index']
+        outputLayerIdx = interpreter.get_output_details()[0]['index']
+
+        # Setting input size.
+        if resize:
+            interpreter.resize_tensor_input(inputLayerIdx, x.shape)
+
+        interpreter.allocate_tensors()
+        interpreter.set_tensor(inputLayerIdx, x)
+        interpreter.invoke()
+        y = interpreter.get_tensor(outputLayerIdx)
+
+        gotFrames = y.shape[1]
+        self.assertTrue(
+            gotFrames == wantFrames,
+            f"output number of frames ({gotFrames}) does not match expected ({wantFrames})",
+        )
+
+        gotDim = y.shape[-1]
+        self.assertTrue(
+            gotDim == wantDim,
+            f"output feature dimension ({gotDim}) does not match expected ({wantDim})",
+        )
+
     def test_ConvertTFLite(self):
 
-        cfg = self.defaultCfg()
-        input_size = 16000 * 3
+        tests = {
+            "fixed_input": {
+                "input_shape": 16000 * 3,
+                "inputs": [(16000 * 3, 298)],  # (numSamples, wantFrames)
+                "framing": {"dynamic_input_shape": False},
+            },
+            "dynamic_input": {
+                "input_shape": None,
+                "inputs": [(16000 * 1, 98), (16000 * 3, 298), (16000 * 2, 198)],
+                "framing": {"dynamic_input_shape": True},
+            },
+        }
 
-        # Creating MFCC extraction model.
-        mdl = Sequential([
-            Input((input_size, )),
-            Framing(**cfg["framing"]),
-            MFCC(**cfg["mfcc"]),
-        ])
+        for name, overrides in tests.items():
+            with self.subTest(name=name, overrides=overrides):
+                cfg = self.defaultCfg()
+                cfg["framing"].update(overrides["framing"])
 
-        # Saving model and converting to TF Lite.
-        with TemporaryDirectory() as mdlPath, \
-                NamedTemporaryFile(suffix='.tflite') as tflitePath:
-            mdl.save(mdlPath)
-            SavedModel2TFLite(mdlPath, tflitePath.name)
+                # Creating Filter Bank extraction model.
+                mdl = Sequential([
+                    Input((overrides["input_shape"], )),
+                    Framing(**cfg["framing"]),
+                    MFCC(**cfg["mfcc"]),
+                ])
+
+                wantDim = cfg["mfcc"]["num_mfccs"]
+                resize = cfg["framing"]["dynamic_input_shape"]
+
+                # Saving model and converting to TF Lite.
+                with TemporaryDirectory() as mdlPath, \
+                        NamedTemporaryFile(suffix='.tflite') as tflitePath:
+                    mdl.save(mdlPath)
+                    SavedModel2TFLite(mdlPath, tflitePath.name)
+
+                    # Testing if inference works.
+                    interpreter = tf.lite.Interpreter(model_path=tflitePath.name)
+                    for numSamples, wantFrames in overrides["inputs"]:
+                        with self.subTest(name=name, num_samples=numSamples):
+                            x = np.random.random((1, numSamples)).astype(np.float32)
+                            self.checkTFLiteInference(interpreter, x, wantFrames, wantDim, resize)
 
     def test_FilterBank(self):
 
@@ -133,14 +187,6 @@ class TestMFCCLayer(unittest.TestCase):
                 ])
 
                 got = mdl(samples).numpy()
-
-                # np.set_printoptions(threshold=13, linewidth=120, suppress=True)
-                # print(f"got = \n{got[0]}")
-                # print(f"want = \n{want[0]}")
-                
-                # print(f"got.shape = {got.shape}")
-                # print(f"want.shape = {want.shape}")
-
                 self.compareFeats(want, got)
 
 


### PR DESCRIPTION
  - Refactored the `Framing` layer to be able to handle dynamic input
    shapes at inference time. The input to the model at build time can
    have unknown shape; the shape must then be be set at inference time
    using resize_input_tensor() and allocate_tensors().

  - Updated the unit tests for `FilterBank` and `MFCC` to also test
    dynamic input shapes.

  - Updated docstrings in `MFCC` and fixed `get_config()`.