### PR TITLE
fix(dsp/layers): index range for `StatsPooling` when subsampling was falling short

### DIFF
--- a/kaldi_tflite/lib/layers/dsp/mfcc_test.py
+++ b/kaldi_tflite/lib/layers/dsp/mfcc_test.py
@@ -152,7 +152,7 @@ class TestMFCCLayer(unittest.TestCase):
                             x = np.random.random((1, numSamples)).astype(np.float32)
                             self.checkTFLiteInference(interpreter, x, wantFrames, wantDim, resize)
 
-    def test_CMVN(self):
+    def test_MFCC(self):
 
         # Default config overrides
         testNames = [f"16000_{i:03d}" for i in range(1, 49)]

--- a/kaldi_tflite/lib/layers/stats/stats_pooling.py
+++ b/kaldi_tflite/lib/layers/stats/stats_pooling.py
@@ -174,7 +174,7 @@ class StatsPooling(Layer):
                 false_fn=lambda: end,
             )
 
-        return start, end
+        return start, end+1
 
     def getIndicesToEval(self, inputTimesteps: Union[int, tf.Tensor]) -> tf.Tensor:
 
@@ -198,7 +198,7 @@ class StatsPooling(Layer):
 
         # We will mask any indices outside the bounds when computing statistics.
         # mask has shape = (numEval, windowWidth). Adding dimensions along the
-        # batch and feature axis to facililate multiplying with 'gathered'
+        # batch and feature axis to facilitate multiplying with 'gathered'
         # inputs. Final shape of mask = (1, numEval, windowWidth, 1).
         mask = tf.logical_and(tf.greater_equal(indices, 0), tf.less(indices, inputTimesteps))
         mask = tf.expand_dims(tf.expand_dims(mask, -1), 0)


### PR DESCRIPTION
  - The index range computed when subsampling is specified in the `StatsPooling`
    layer (i.e. input_period or output_period > 1), was stopping one frame before
    the end. So for 900 input frames, and output period of 300, we were getting
    2 frames of output instead of 3.

  - Also fixed a couple of typos.