### PR TITLE
chore: update to tensorflow 2.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.7.11
   - pip=21.2.2
   - pip:
-    - tensorflow==2.6.2
+    - tensorflow==2.8.0
     - pyyaml==6.0
     - tqdm==4.62.3
     - pytest==6.2.5

--- a/kaldi_tflite/lib/layers/dsp/mfcc_test.py
+++ b/kaldi_tflite/lib/layers/dsp/mfcc_test.py
@@ -122,12 +122,25 @@ class TestMFCCLayer(unittest.TestCase):
                 "inputs": [(16000 * 1, 98), (16000 * 3, 298), (16000 * 2, 198)],
                 "framing": {"dynamic_input_shape": True},
             },
+            "with_dithering_fixed_input": {
+                "input_shape": 16000 * 3,
+                "inputs": [(16000 * 3, 298)],  # (numSamples, wantFrames)
+                "framing": {"dynamic_input_shape": False},
+                "mfcc": {"dither": 1.0},
+            },
+            "with_dithering_dynamic_input": {
+                "input_shape": None,
+                "inputs": [(16000 * 1, 98), (16000 * 3, 298), (16000 * 2, 198)],
+                "framing": {"dynamic_input_shape": True},
+                "mfcc": {"dither": 1.0},
+            },
         }
 
         for name, overrides in tests.items():
             with self.subTest(name=name, overrides=overrides):
                 cfg = self.defaultCfg()
-                cfg["framing"].update(overrides["framing"])
+                cfg["framing"].update(overrides.get("framing", {}))
+                cfg["mfcc"].update(overrides.get("mfcc", {}))
 
                 # Creating Filter Bank extraction model.
                 mdl = Sequential([

--- a/kaldi_tflite/lib/layers/dsp/windowing_test.py
+++ b/kaldi_tflite/lib/layers/dsp/windowing_test.py
@@ -67,16 +67,6 @@ class TestWindowingLayer(unittest.TestCase):
 
     def checkConvertTFLite(self, layer: Windowing):
 
-        # TODO (shahruk): With `dithering` enabled, the conversion fails because
-        # the tf.RandomStandardNormal op isn't natively supported in Tensorflow
-        # Lite (requires Flex Ops). Need to find a workaround that does not
-        # involve needing to link to Flex lib for inference. Pre-computing
-        # random dither values and storing it in the model could be one
-        # solution.
-        if layer.dither > 0:
-            print("TF Lite conversion not supported with dithering enabled, skipping check")
-            return
-
         i = Input((None, 256))
         mdl = Model(
             inputs=i,
@@ -103,7 +93,7 @@ class TestWindowingLayer(unittest.TestCase):
             {"preemphasis_coefficient": 0.0},
             {"preemphasis_coefficient": 0.90},
             {"raw_energy": False},
-            {"dither": 0.1},
+            {"dither": 1.0},
         ]
 
         frames = np.random.random((1, 1000, 256))

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'librosa==0.8.1',
     ],
     install_requires=[
-        'tensorflow==2.6.2',
+        'tensorflow==2.8.0',
         'pyyaml==6.0',
         'tqdm==4.62.3',
     ],


### PR DESCRIPTION
  - The new version of tensorflow also adds `tf.random.normal` to list
    of supported ops in TF Lite. This will now allow dithering to be
    enabled in the TFLite models. So tests that were previously skipped
    when dithering was enabled are now run.